### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Factory/Driver.php
+++ b/lib/Factory/Driver.php
@@ -32,6 +32,13 @@ class Passwd_Factory_Driver extends Horde_Core_Factory_Base
     private $_backends = null;
 
     /**
+     * Backends
+     *
+     * @var array
+     */
+    public $backends = array();
+
+    /**
      * Created Passwd_Driver instances.
      *
      * @var array

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Passwd/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Passwd/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Passwd Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Passwd/TestCase.php
+++ b/test/Passwd/TestCase.php
@@ -8,7 +8,7 @@
  * @package    Passwd
  * @subpackage UnitTests
  */
-class Passwd_TestCase extends PHPUnit_Framework_TestCase
+class Passwd_TestCase extends Horde_Test_Case
 {
     protected function getInjector()
     {

--- a/test/Passwd/Unit/Driver/SqlTest.php
+++ b/test/Passwd/Unit/Driver/SqlTest.php
@@ -13,13 +13,13 @@ class Passwd_Unit_Driver_SqlTest extends Passwd_TestCase
 {
     private $driver;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::createBasicPasswdSetup(new Horde_Test_Setup());
         parent::setUpBeforeClass();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $GLOBALS['injector'] = $this->getInjector();
         $factory = new Passwd_Factory_Driver($this->getInjector());
@@ -42,11 +42,10 @@ class Passwd_Unit_Driver_SqlTest extends Passwd_TestCase
         $this->assertInstanceOf('Passwd_Driver', $this->driver);
     }
 
-    /**
-     * @expectedException Passwd_Exception
-     */
     public function testChangePasswordFailsForNonexistingUser()
     {
+        $this->expectException('Passwd_Exception');
+
         $res = $this->driver->changePassword('Patricia', 'alt', 'neu');
     }
 

--- a/test/Passwd/Unit/Factory/DriverTest.php
+++ b/test/Passwd/Unit/Factory/DriverTest.php
@@ -14,7 +14,7 @@ class Passwd_Unit_Factory_DriverTest extends Passwd_TestCase
 {
     protected $_backends = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->markTestIncomplete('Factories with configuration files don\'t work out of the box.');
         $this->_backends = array(


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-passwd/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-passwd/-/blob/debian-sid/debian/patches/1012_php8.2.patch
